### PR TITLE
Fix comments section getting left behind

### DIFF
--- a/src/showYoutubeComments.css
+++ b/src/showYoutubeComments.css
@@ -1,10 +1,11 @@
-#secondary {
+#secondary,
+#primary {
     height: calc(100vh - 80px);
     overflow: scroll;
     overflow-x: hidden;
     overscroll-behavior: contain;
 }
 
-#secondary::-webkit-scrollbar {
+::-webkit-scrollbar {
     display: none;
 }


### PR DESCRIPTION
Fix comments section getting left behind when scrolling the Watch Next section

Now you can scroll down the page, and still read comments while browsing the Watch Next section.